### PR TITLE
Additional tests for version for 100% coverage

### DIFF
--- a/baleen/version.py
+++ b/baleen/version.py
@@ -26,15 +26,15 @@ __version_info__ = {
 }
 
 
-def get_version(short=False):
+def get_version(short=False,version_info=__version_info__):
     """
     Computes a string representation of the version from __version_info__.
     """
-    assert __version_info__['releaselevel'] in ('alpha', 'beta', 'final')
-    vers = ["%(major)i.%(minor)i" % __version_info__, ]
-    if __version_info__['micro']:
-        vers.append(".%(micro)i" % __version_info__)
-    if __version_info__['releaselevel'] != 'final' and not short:
-        vers.append('%s%i' % (__version_info__['releaselevel'][0],
-                              __version_info__['serial']))
+    assert version_info['releaselevel'] in ('alpha', 'beta', 'final')
+    vers = ["%(major)i.%(minor)i" % version_info, ]
+    if version_info['micro']:
+        vers.append(".%(micro)i" % version_info)
+    if version_info['releaselevel'] != 'final' and not short:
+        vers.append('%s%i' % (version_info['releaselevel'][0],
+                              version_info['serial']))
     return ''.join(vers)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,56 @@
+# tests
+# Testing for the baleen version module
+#
+# Author:   Will Voorhees <developer@willz.org>
+# Created:  Thu Jun 02 17:06:15 2016 -0700
+#
+# Copyright (C) 2016 Bengfort.com
+# For license information, see LICENSE.txt
+#
+
+"""
+Testing for the baleen module
+"""
+
+##########################################################################
+## Imports
+##########################################################################
+
+import unittest
+import baleen
+
+##########################################################################
+## Test Cases
+##########################################################################
+
+class GetVersionTest(unittest.TestCase):
+
+    def test_final_version(self):
+        """
+        Assert that the final version is correct
+        """
+        test_version_info = {
+            'major': 0,
+            'minor': 3,
+            'micro': 3,
+            'releaselevel': 'final',
+            'serial': 0,
+        }
+        
+        self.assertEqual("0.3.3", baleen.get_version(short=True,version_info=test_version_info))
+        self.assertEqual("0.3.3", baleen.get_version(short=False,version_info=test_version_info))
+
+    def test_non_final_version(self):
+        """
+        Assert that the non-final version is correct
+        """
+        test_version_info = {
+            'major': 0,
+            'minor': 3,
+            'micro': 3,
+            'releaselevel': 'alpha',
+            'serial': 0,
+        }
+
+        self.assertEqual("0.3.3", baleen.get_version(short=True,version_info=test_version_info))
+        self.assertEqual("0.3.3a0", baleen.get_version(short=False, version_info=test_version_info))


### PR DESCRIPTION
Reworked get_version to allow for easier testing and added tests for the case where we aren't publishing a 'final' version.  This brings test coverage for that function up to 100%.
