### PR TITLE
Additional tests for export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ feedparser==5.2.1
 requests==2.9.1
 
 ## Database
-pymongo==3.2.1
+pymongo==3.2.2
 mongoengine==0.10.6
 blinker==1.4
 
@@ -42,7 +42,6 @@ Werkzeug==0.11.5
 ## Uncomment and install for development
 #nose==1.3.7
 #coverage==4.0.3
-#mock==1.3.0
 #funcsigs==0.4
 #pbr==1.8.1
 #mongomock==3.2.1

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -18,15 +18,65 @@ Test the export module - to generate a corpus for machine learning.
 ##########################################################################
 
 import unittest
+import logging
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from mongomock import MongoClient as MockMongoClient
+from unittest import mock
+from unittest.mock import MagicMock
 
 from baleen.export import *
+from baleen.feed import *
+from baleen.models import connect
 from baleen.exceptions import ExportError
 
+##########################################################################
+## Fixtures
+##########################################################################
+
+BOOKS_FEED = Feed(
+    title = 'The Rumpus.net',
+    link = 'http://therumpus.net/feed/',
+    urls = {'htmlurl': 'http://therumpus.net'},
+    category = 'books',
+)
+BOOKS_POST = Post(
+    feed=BOOKS_FEED,
+    title="My Awesome Post",
+    content="books",
+    url="http://example.com/books.html",
+)
+
+POLITICS_FEED = Feed(
+    title = 'The Politics Site',
+    link = 'http://politicsrock.net/feed/',
+    urls = {'htmlurl': 'http://politicsrock.net'},
+    category = 'politics',
+)
+POLITICS_POST = Post(
+    feed=POLITICS_FEED,
+    title="My Awesome Political Post",
+    content="political parties",
+    url="http://example.com/politics.html",
+)
+
+FOOD_FEED = Feed(
+    title = 'I love food',
+    link = 'http://foodisthebest.com/atom',
+    urls = {'htmlurl': 'http://foodisthebest.com'},
+    category = 'food',
+)
+FOOD_POST = Post(
+    feed=FOOD_FEED,
+    title="Hamburgers are Good",
+    content="ground meat",
+    url="http://example.com/mmmmm.html",
+)
+
+CATEGORIES_IN_DB = [
+    BOOKS_FEED.category,
+    POLITICS_FEED.category,
+    FOOD_FEED.category,
+]
 
 ##########################################################################
 ## Export Tests
@@ -34,9 +84,42 @@ from baleen.exceptions import ExportError
 
 class ExportTests(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        """
+        Create the mongomock connection
+        """
+        cls.conn = connect(host='mongomock://localhost')
+        assert isinstance(cls.conn, MockMongoClient)
+
+        # Clear out the database
+        for feed in Feed.objects(): feed.delete()
+        for post in Post.objects(): post.delete()
+        assert Feed.objects.count() == 0
+        assert Post.objects.count() == 0
+
+        # Set up test feeds
+        FeedSync(BOOKS_FEED).sync()
+        BOOKS_POST.save()
+        FeedSync(FOOD_FEED).sync()
+        FOOD_POST.save()
+        FeedSync(POLITICS_FEED).sync()
+        POLITICS_POST.save()
+
+        assert Feed.objects.count() == 3
+        assert Post.objects.count() == 3
+
+    @classmethod
+    def tearDownClass(self):
+        """
+        Drop the mongomock connection
+        """
+        assert isinstance(self.conn, MockMongoClient)
+        self.conn = None
+
     def test_scheme_specification(self):
         """
-        Assert that only known schemes are allowed.
+        Assert that only known schemes are allowed
         """
 
         # Make sure good schemes don't error
@@ -50,3 +133,119 @@ class ExportTests(unittest.TestCase):
         for scheme in ('text', 'txt', 'bson', 'xml', 'yaml'):
             with self.assertRaises(ExportError):
                 exporter = MongoExporter("/tmp/corpus", scheme=scheme)
+
+    def test_categories_default(self):
+        """
+        Assert that categories are set to default when not provided
+        """
+
+        exporter = MongoExporter("/tmp/corpus")
+        self.assertCountEqual(CATEGORIES_IN_DB, exporter.categories)
+
+    def test_categories_provided(self):
+        """
+        Assert that provided categories are returned
+        """
+        categories = ["TestCategory", "Another Category", "Unicode ĆăƮĖƓƠŕƔ"]
+        exporter = MongoExporter("/tmp/corpus", categories=categories)
+        self.assertCountEqual(categories, exporter.categories)
+
+    def test_feeds_for_list_of_categories(self):
+        """
+        Assert that getting feeds for a list of categories works
+        """
+        exporter = MongoExporter("/tmp/corpus", categories=CATEGORIES_IN_DB)
+        expected_feeds = [POLITICS_FEED, FOOD_FEED]
+        test_categories = ["politics", "food"]
+        self.assertCountEqual(expected_feeds , exporter.feeds(categories=test_categories))
+
+    def test_feeds_for_category_string(self):
+        """
+        Assert that getting feeds for a category as a string
+        """
+        exporter = MongoExporter("/tmp/corpus", categories=CATEGORIES_IN_DB)
+        self.assertCountEqual([POLITICS_FEED], exporter.feeds(categories="politics"))
+
+    def test_feeds_for_all_categories(self):
+        """
+        Assert that getting feeds with a category returns for all categories
+        """
+        exporter = MongoExporter("/tmp/corpus", categories=CATEGORIES_IN_DB)
+        self.assertCountEqual([POLITICS_FEED, FOOD_FEED, BOOKS_FEED], exporter.feeds())
+
+    def test_writing_readme(self):
+        """
+        Assert that a readme file is written correctly
+        """
+        exporter = MongoExporter("/tmp/corpus", categories=CATEGORIES_IN_DB)
+        exporter.state = State.Finished
+        exporter.readme("/tmp/readme")
+
+        # TODO Assert appropriate readme file
+
+    def test_writing_readme_fails(self):
+        """
+        Assert writing readme file fails when in an incorrect state
+        """
+        exporter = MongoExporter("/tmp/corpus", categories=CATEGORIES_IN_DB)
+        with self.assertRaises(ExportError):
+            exporter.readme("/tmp/readme")
+
+    def test_generating_posts_fails(self):
+        """
+        Assert generating posts fails when in an incorrect state
+        """
+        exporter = MongoExporter("/tmp/corpus", categories=CATEGORIES_IN_DB)
+        exporter.state = "Some crazy thing"
+        with self.assertRaises(ExportError):
+            for post, category in exporter.posts():
+                self.fail("Should never get to the point where we touch posts")
+
+    """
+    MockMongoClient doesn't have a rewind method:
+    https://github.com/vmalloc/mongomock/blob/develop/mongomock/collection.py#L1498
+
+    This forces us to mock the post() method here.
+    """
+    def test_export(self):
+        """
+        Assert that we can export posts
+        """
+        exporter = MongoExporter("/tmp/corpus", categories=CATEGORIES_IN_DB)
+
+        # Mock Mongo calls that aren't supported in MockMongoClient
+        post_categories = [
+            (BOOKS_POST, BOOKS_FEED.category),
+            (FOOD_POST, FOOD_FEED.category),
+            (POLITICS_POST, POLITICS_FEED.category),
+        ]
+        exporter.posts = MagicMock(return_value=post_categories)
+        exporter.export()
+
+    def test_export_with_root_path_failure(self):
+        """
+        Assert that root path failures are raised
+        """
+        root_path = "/tmp/corpus"
+        exporter = MongoExporter(root_path, categories=CATEGORIES_IN_DB)
+        os.path.exists = lambda path: False if path == root_path else True
+        os.mkdir = lambda success: True # Mock directory creation
+        os.path.isdir = lambda path: False if path == root_path else True
+
+        with self.assertRaises(ExportError):
+            exporter.export()
+
+    def test_export_with_category_path_failure(self):
+        """
+        Assert that category path failures are raised
+        """
+        root_path = "/tmp/corpus"
+        exporter = MongoExporter(root_path, categories=CATEGORIES_IN_DB)
+        for category in CATEGORIES_IN_DB:
+            category_path = os.path.join(root_path, category)
+            os.path.exists = lambda path: False if path == category_path else True
+            os.mkdir = lambda success: True # Mock directory creation
+            os.path.isdir = lambda path: False if path == category_path else True
+
+            with self.assertRaises(ExportError):
+                exporter.export()


### PR DESCRIPTION
Bumps the export code coverage from 36% to 86%.  I banged my head against the wall for a really long time on the posts iterator failing due to a missing .rewind() method buried deep in the no_cache() version of the Mongo query set.  Turns out that the Mongo mock doesn't have that functionality, so of course it failed.  I opted to just mock the posts() method in our stuff to get around this.  If we can sort out the Mongo mock, test coverage can increase to more like 95%.
