### PR TITLE
Add tests to sanitize

### DIFF
--- a/baleen/export.py
+++ b/baleen/export.py
@@ -37,7 +37,11 @@ from readability.readability import Document
 ##########################################################################
 
 DTFMT   = "%b %d, %Y at %H:%M"
-SCHEMES = ('json', 'html', 'safe', 'raw', 'text')
+RAW = 'raw'
+SAFE = 'safe'
+TEXT = 'text'
+SANITIZE_LEVELS = (RAW, SAFE, TEXT)
+SCHEMES = ('json', 'html') + SANITIZE_LEVELS
 State   = Enum('State', 'Init, Started, Finished')
 
 
@@ -230,21 +234,50 @@ class MongoExporter(object):
         self.feedinfo(os.path.join(self.root, "feeds.json"))
 
     def sanitize_html(self, html, level):
-        if level == 'safe':
+        """
+        Return a sanitized version of html content
+        :param html: the content to sanitized
+        :param level: the type of sanitization - one of ['raw', 'safe', 'text', None]
+        :return: sanitized content
+        """
+        if level == SAFE:
             return self._get_safe_html(html)
-        elif level == 'raw':
+        elif level == RAW:
             return self._get_raw_html(html)
-        elif level == 'text':
+        elif level == TEXT:
             return self._get_text_from_html(html)
+        elif level is None:
+            return html
+
+        raise ExportError(
+            "{level} is not a supported sanitize_html level.".format(
+                level=level
+            )
+        )
 
     def _get_raw_html(self, html):
+        """
+        :param html: html content
+        :return: the unmodified html
+        """
         return html
 
     def _get_safe_html(self, html):
+        """
+        Applies Readability's sanitize() method to content.
+        :param html: the content to sanitize
+        :return: the body of the html content minus html tags
+        """
         return Document(html).summary()
 
     def _get_text_from_html(self, html):
-        text = Document(html).summary()
+        """
+        Applies the 'safe' level of sanitization, removes newlines,
+        and converts the html entity for ampersand into the ampersand character.
+        :param html: the content to sanitize
+        :return: sanitized content
+        """
+        text = self._get_safe_html(html)
         text = bleach.clean(text, tags=[], strip=True)
         text = text.strip()
         text = text.replace("\n", "")

--- a/baleen/export.py
+++ b/baleen/export.py
@@ -178,7 +178,7 @@ class MongoExporter(object):
         with open(path, 'w') as f:
             f.write(feeds.to_json(indent=2))
 
-    def export(self, root=None, categories=None, level='safe'):
+    def export(self, root=None, categories=None, level=SAFE):
         """
         Runs the export of the posts to disk.
         """

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -249,3 +249,59 @@ class ExportTests(unittest.TestCase):
 
             with self.assertRaises(ExportError):
                 exporter.export()
+
+
+class SanitizeHtmlTests(unittest.TestCase):
+    """ Tests the exporter's sanitize methods """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sample_html = ('<html>'
+                           '<head><script>javascript here</script></head>'
+                           '<body><b>body &amp;\n mind</b></body>'
+                           '</html>')
+
+        cls.conn = connect(host='mongomock://localhost')
+        assert isinstance(cls.conn, MockMongoClient)
+        root_path = '/tmp/corpus'
+        cls.exporter = MongoExporter(root_path, categories=CATEGORIES_IN_DB)
+
+    @classmethod
+    def tearDownClass(self):
+        """
+        Drop the mongomock connection
+        """
+        assert isinstance(self.conn, MockMongoClient)
+        self.conn = None
+
+    def test_sanitize_requires_a_valid_level(self):
+        """  Assert that sanitize_html requires a supported level """
+        with self.assertRaises(ExportError):
+            self.exporter.sanitize_html(self.sample_html, "bogus")
+
+    def test_sanitize_returns_input_for_level_none(self):
+        """  Assert that sanitize_html returns unmodified input for level None """
+        self.assertEqual(self.exporter.sanitize_html(self.sample_html, None), self.sample_html)
+
+    def test_sanitize_raw(self):
+        """  Assert that sanitize raw returns the content as submitted """
+        self.assertEqual(self.exporter.sanitize_html(self.sample_html, RAW), self.sample_html)
+
+    def test_sanitize_safe(self):
+        """  Assert that sanitize safe applies Readability and returns the body """
+
+        # Give Readability a simpler HTML sample
+        sample_html = ('<html>'
+                       '<head><script>javascript here</script></head>'
+                       '<body>body</body>'
+                       '</html>')
+        expected = '<body id="readabilityBody">body</body>'
+        self.assertEqual(self.exporter.sanitize_html(sample_html, SAFE), expected)
+
+    def test_sanitize_text(self):
+        """
+        Assert that sanitize text strips HTML tags, removes newlines,
+         and converts the html entity ampersand into an ampersand character
+        """
+        expected = 'body & mind'
+        self.assertEqual(self.exporter.sanitize_html(self.sample_html, TEXT), expected)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -252,7 +252,7 @@ class ExportTests(unittest.TestCase):
 
 
 class SanitizeHtmlTests(unittest.TestCase):
-    """ Tests the exporter's sanitize methods """
+    """ Tests the exporter's HTML sanitize methods """
 
     @classmethod
     def setUpClass(cls):
@@ -275,22 +275,22 @@ class SanitizeHtmlTests(unittest.TestCase):
         self.conn = None
 
     def test_sanitize_requires_a_valid_level(self):
-        """  Assert that sanitize_html requires a supported level """
+        """  Sanitize_html requires a supported level """
         with self.assertRaises(ExportError):
             self.exporter.sanitize_html(self.sample_html, "bogus")
 
     def test_sanitize_returns_input_for_level_none(self):
-        """  Assert that sanitize_html returns unmodified input for level None """
+        """  sanitize_html returns unmodified input for level None """
         self.assertEqual(self.exporter.sanitize_html(self.sample_html, None), self.sample_html)
 
     def test_sanitize_raw(self):
-        """  Assert that sanitize raw returns the content as submitted """
+        """  Sanitize level raw returns the content as submitted """
         self.assertEqual(self.exporter.sanitize_html(self.sample_html, RAW), self.sample_html)
 
     def test_sanitize_safe(self):
-        """  Assert that sanitize safe applies Readability and returns the body """
+        """  Sanitize level safe applies Readability and returns the body """
 
-        # Give Readability a simpler HTML sample
+        # Give Readability a simpler HTML sample to keep its parse strategy simple
         sample_html = ('<html>'
                        '<head><script>javascript here</script></head>'
                        '<body>body</body>'
@@ -300,7 +300,7 @@ class SanitizeHtmlTests(unittest.TestCase):
 
     def test_sanitize_text(self):
         """
-        Assert that sanitize text strips HTML tags, removes newlines,
+        Sanitize level text strips HTML tags, removes newlines,
          and converts the html entity ampersand into an ampersand character
         """
         expected = 'body & mind'


### PR DESCRIPTION
#70 write tests for sanitize.

Added constants for the sanitize levels.
`sanitize_html` didn't return anything if the sanitize level isn't recognized.  Returns the unmodified content if level None, raises an error if unknown level. 