### PR TITLE
Issue #89 - add a command line flag to export for sanitize level

### DIFF
--- a/baleen/console/commands/export.py
+++ b/baleen/console/commands/export.py
@@ -22,7 +22,9 @@ import baleen.models as db
 
 from commis import Command
 from baleen.console.utils import csv
-from baleen.export import MongoExporter, SCHEMES
+from baleen.export import MongoExporter, SCHEMES, JSON
+from baleen.utils.text import SAFE, SANITIZE_LEVELS
+
 from baleen.utils.timez import Timer
 
 
@@ -47,9 +49,15 @@ class ExportCommand(Command):
         },
         ('-S', '--scheme'): {
             'type': str,
-            'default': 'json',
+            'default': JSON,
             'choices': SCHEMES,
             'help': 'specify the output format for the corpus',
+        },
+        ('-Z', '--sanitize'): {
+            'type': str,
+            'default': SAFE,
+            'choices': SANITIZE_LEVELS,
+            'help': 'specify what sanitization to apply to html exports',
         },
         'location': {
             'nargs': 1,
@@ -69,7 +77,7 @@ class ExportCommand(Command):
 
         # Create the exporter object
         exporter = MongoExporter(
-            root, categories=args.categories, scheme=args.scheme
+            root, categories=args.categories, scheme=args.scheme, sanitize_level=args.sanitize
         )
 
         # If list categories is true, list them and exit.
@@ -77,7 +85,7 @@ class ExportCommand(Command):
             return "\n".join(sorted(exporter.categories))
 
         with Timer() as t:
-            exporter.export(level=args.scheme)
+            exporter.export()
 
         return (
             "Baleen corpus export complete in {}\n"

--- a/baleen/export.py
+++ b/baleen/export.py
@@ -213,14 +213,17 @@ class MongoExporter(object):
 
             path = os.path.join(category_filepaths[category], "{}.{}".format(post.id, self.scheme))
 
-            with codecs.open(path, 'w', encoding='utf-8') as f:
-                action = {
-                    JSON: lambda: post.to_json(indent=2),
-                    HTML: lambda: post.htmlize(sanitize=level)
-                }[self.scheme]
+            try:
+                with codecs.open(path, 'w', encoding='utf-8') as f:
+                    action = {
+                        JSON: lambda: post.to_json(indent=2),
+                        HTML: lambda: post.htmlize(sanitize=level)
+                    }[self.scheme]
 
-                f.write(action())
-
+                    f.write(action())
+            except FileNotFoundError as e:
+                msg = "FileNotFoundError ({0}): {1}".format(e.errno, e.strerror)
+                raise ExportError(msg)
         # Mark the export as finished and write the README to the corpus.
         self.state = State.Finished
         self.readme(os.path.join(root, "README"))

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -106,7 +106,7 @@ class ExportTests(unittest.TestCase):
         assert Feed.objects.count() == 3
         assert Post.objects.count() == 3
         cls.root_dir = mkdtemp(prefix="baleen")
-        cls.corpus_dir = "{}/corpus".format(cls.root_dir)
+        cls.corpus_dir = os.path.join(cls.root_dir, "corpus")
 
     @classmethod
     def tearDownClass(self):
@@ -178,7 +178,7 @@ class ExportTests(unittest.TestCase):
         """
         exporter = MongoExporter(root=self.corpus_dir, categories=CATEGORIES_IN_DB)
         exporter.state = State.Finished
-        exporter.readme("{}/readme".format(self.root_dir))
+        exporter.readme = os.path.join(self.root_dir, "readme")
 
         # TODO Assert appropriate readme file
 
@@ -188,7 +188,7 @@ class ExportTests(unittest.TestCase):
         """
         exporter = MongoExporter(root=self.corpus_dir, categories=CATEGORIES_IN_DB)
         with self.assertRaises(ExportError):
-            exporter.readme("{}/readme".format(self.root_dir))
+            exporter.readme = os.path.join(self.root_dir, "readme")
 
     def test_generating_posts_fails(self):
         """

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -22,6 +22,8 @@ from unittest.mock import MagicMock
 
 from mongomock import MongoClient as MockMongoClient
 
+from tempfile import mkdtemp
+
 from baleen.export import *
 from baleen.feed import *
 from baleen.models import connect
@@ -103,8 +105,8 @@ class ExportTests(unittest.TestCase):
 
         assert Feed.objects.count() == 3
         assert Post.objects.count() == 3
-        cls.root_dir = "/tmp"
-        cls.corpus_dir = "/tmp/corpus"
+        cls.root_dir = mkdtemp(prefix="baleen")
+        cls.corpus_dir = "{}/corpus".format(cls.root_dir)
 
     @classmethod
     def tearDownClass(self):
@@ -176,7 +178,7 @@ class ExportTests(unittest.TestCase):
         """
         exporter = MongoExporter(root=self.corpus_dir, categories=CATEGORIES_IN_DB)
         exporter.state = State.Finished
-        exporter.readme("/tmp/readme")
+        exporter.readme("{}/readme".format(self.root_dir))
 
         # TODO Assert appropriate readme file
 
@@ -186,7 +188,7 @@ class ExportTests(unittest.TestCase):
         """
         exporter = MongoExporter(root=self.corpus_dir, categories=CATEGORIES_IN_DB)
         with self.assertRaises(ExportError):
-            exporter.readme("/tmp/readme")
+            exporter.readme("{}/readme".format(self.root_dir))
 
     def test_generating_posts_fails(self):
         """


### PR DESCRIPTION

 * Added -Z and --sanitize flag to command
 * Added sanitize_level attribute to Exporter class in the initializer, to be consistent with scheme
 * Addded sanitize_level argument to export method 
 * Added tests for invalid scheme and sanitize level
* '/tmp/corpus' was getting repeated a lot in tests, so set a self attribute in setUp.
* Restructured export method into smaller methods, since I was doing some duplicate work in __init__ and export, and it makes them easier to test. 
* Don't set object attributes in export(); make export related functions take values from parameters rather than self.  Previously export() updated the self values with the parameter values, and it feels weird to make a persisting change to the object when calling export.  Sending values in parameters means not having to look them up in self. 
 